### PR TITLE
Check if window is defined

### DIFF
--- a/getscreenmedia.js
+++ b/getscreenmedia.js
@@ -130,7 +130,7 @@ module.exports = function (constraints, cb) {
     }
 };
 
-window.addEventListener('message', function (event) {
+typeof window !== 'undefined' && window.addEventListener('message', function (event) {
     if (event.origin != window.location.origin) {
         return;
     }


### PR DESCRIPTION
allows importing in a node environment

This lets me run tests on my code that imports hark; it refuses to compile in the node environment otherwise.

Let me know if this is OK or if I could improve the commit, I'm happy to do any leg work (e.g. style)
